### PR TITLE
ignore .babelrc when publishing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ test/
 
 .gitignore
 .npmignore
+.babelrc


### PR DESCRIPTION
Fixes a problem in https://github.com/StoDevX/AAO-React-Native/pull/2293