### PR TITLE
Allow grouping by original groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.3.0
+- Added new `{groupBy: sis}` optional second parameter to `convertTimeStringsToOfferings`
+    - It maintains the groupings that SIS gives us, instead of re-grouping multiple times into a single day
+
 ## 2.2.13
 - Fixes bundled package – I had forgotten how to publish properly
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,29 @@ Example:
 
 ```js
 // input
-['MT 0100-0400PM', 'MF 0905-1000']
+course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
+
+convertTimeStringsToOfferings(course, {groupBy: 'day'})
 
 // output
 [
 	{ day: 'Mo', times: [{ start: 1300, end: 1600 }, { start: 905, end: 1000 }] },
 	{ day: 'Tu', times: [{ start: 1300, end: 1600 }] },
 	{ day: 'Fr', times: [{ start: 905,  end: 1000 }] },
+]
+```
+
+You can also request that the offerings be grouped like SIS does:
+
+```js
+// input
+course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
+
+convertTimeStringsToOfferings(course, {groupBy: 'sis'})
+
+// output
+[
+    { days: ['Mo', 'Tu'], start: 1300, end: 1600 },
+    { days: ['Mo', 'Fr'], start: 905,  end: 1000 },
 ]
 ```

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-exports.checkCoursesForTimeConflicts = require('./lib/check-courses-for-time-conflicts').default
-exports.checkScheduleForTimeConflicts = require('./lib/check-schedule-for-time-conflicts').default
-exports.convertTimeStringsToOfferings = require('./lib/convert-time-strings-to-offerings').default
-exports.findScheduleTimeConflicts = require('./lib/find-schedule-time-conflicts').default
+module.exports.checkCoursesForTimeConflicts = require('./lib/check-courses-for-time-conflicts').default
+module.exports.checkScheduleForTimeConflicts = require('./lib/check-schedule-for-time-conflicts').default
+module.exports.convertTimeStringsToOfferings = require('./lib/convert-time-strings-to-offerings').default
+module.exports.findScheduleTimeConflicts = require('./lib/find-schedule-time-conflicts').default

--- a/src/__tests__/convert-time-strings-to-offerings.test.js
+++ b/src/__tests__/convert-time-strings-to-offerings.test.js
@@ -94,12 +94,56 @@ describe('in groupBy=day mode', () => {
 })
 
 describe('in groupBy=sis mode', () => {
-	test('retains the gay groupings given by SIS', () => {
+	test('retains the day groupings given by SIS', () => {
 		let course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
 
 		let expected = [
 			{days: ['Mo', 'Tu'], start:1300, end:1600},
 			{days: ['Mo', 'Fr'], start:905,  end:1000},
+		]
+
+		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
+
+		expect(actual).toEqual(expected)
+	})
+
+	test('embeds locations correctly', () => {
+		let course = {
+			times: ['MT 0100-0400PM', 'MF 0905-1000'],
+			locations: ['TOH 103', 'RNS 203'],
+		}
+
+		let expected = [
+			{days: ['Mo', 'Tu'], start:1300, end:1600, location: 'TOH 103'},
+			{days: ['Mo', 'Fr'], start:905,  end:1000, location: 'RNS 203'},
+		]
+
+		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
+
+		expect(actual).toEqual(expected)
+	})
+
+	test('overwrites the offering if the same days are given again', () => {
+		let course = {times: ['MT 0100-0400PM', 'MT 0905-1000']}
+
+		let expected = [
+			{days: ['Mo', 'Tu'], start:905, end:1000},
+		]
+
+		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
+
+		expect(actual).toEqual(expected)
+	})
+
+	test('does not overwrite the offering if the same days are given in a different order', () => {
+		let course = {
+			times: ['MT 0100-0400PM', 'TM 0905-1000'],
+			locations: ['Place 1', 'Place 2'],
+		}
+
+		let expected = [
+			{days: ['Mo', 'Tu'], start:1300, end:1600, location: 'Place 1'},
+			{days: ['Tu', 'Mo'], start:905,  end:1000, location: 'Place 2'},
 		]
 
 		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})

--- a/src/__tests__/convert-time-strings-to-offerings.test.js
+++ b/src/__tests__/convert-time-strings-to-offerings.test.js
@@ -65,3 +65,45 @@ test('can join together multiple location/time pairs', () => {
 
 	expect(actual).toEqual(expected)
 })
+
+test('throws an error when an invalid groupBy parameter is passed', () => {
+	let info = {
+		times: ['MF 0905-1000', 'W 1000-1155'],
+		locations: ['TOH 103', 'RNS 203'],
+	}
+
+	const actual = () => convertTimeStringsToOfferings(info, {groupBy: '--invalid--'})
+
+	expect(() => actual()).toThrow('"--invalid--" is not a valid groupBy mode')
+})
+
+describe('in groupBy=day mode', () => {
+	test('groups the "times" by "day" (of the week)', () => {
+		let course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
+
+		let expected = [
+			{day: 'Mo', times: [{start:1300, end:1600}, {start:905, end:1000}]},
+			{day: 'Tu', times: [{start:1300, end:1600}]},
+			{day: 'Fr', times: [{start:905,  end:1000}]},
+		]
+
+		let actual = convertTimeStringsToOfferings(course, {groupBy: 'day'})
+
+		expect(actual).toEqual(expected)
+	})
+})
+
+describe('in groupBy=sis mode', () => {
+	test('retains the gay groupings given by SIS', () => {
+		let course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
+
+		let expected = [
+			{days: ['Mo', 'Tu'], start:1300, end:1600},
+			{days: ['Mo', 'Fr'], start:905,  end:1000},
+		]
+
+		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
+
+		expect(actual).toEqual(expected)
+	})
+})

--- a/src/__tests__/find-time.test.js
+++ b/src/__tests__/find-time.test.js
@@ -22,6 +22,12 @@ test('handles both courses that should and courses that do end in the afternoon'
 	expect(findTime('0100-0400PM')).toEqual({start: 1300, end: 1600})
 })
 
+test('handles coures with explicit AM notation', () => {
+	expect(findTime('1100AM-0400PM')).toEqual({start: 1100, end: 1600})
+	// TODO: this is wierd
+	expect(findTime('100AM-0400')).toEqual({start: 100, end: 1600})
+})
+
 test('handles every variant that the SIS contains', () => {
 	expect(findTime('5:00-9:00')).toEqual({start: 500, end: 900})
 	expect(findTime('7:00-9:00')).toEqual({start: 700, end: 900})

--- a/src/convert-time-strings-to-offerings.js
+++ b/src/convert-time-strings-to-offerings.js
@@ -13,7 +13,7 @@ export default function convertTimeStringsToOfferings(course, {groupBy='day'}={}
 	} else if (groupBy === 'sis') {
 		return convertAndGroupLikeSis(course)
 	} else {
-		throw new Error(`"${groupBy}" is not a valid groupBy mode`)
+		throw new TypeError(`"${groupBy}" is not a valid groupBy mode`)
 	}
 }
 
@@ -56,24 +56,20 @@ function convertAndGroupLikeSis(course) {
 
 		const days = findDays(daystring)
 		const time = findTime(timestring)
+		const key = days.join(',')
 
-		days.forEach(day => {
-			if (!offerings[day]) {
-				offerings[day] = {}
-			}
+		if (!offerings[key]) {
+			offerings[key] = {}
+		}
 
-			let offering = {
-				day: day,
-				times: [assign({}, time)],
-			}
+		let offering = {days, ...time}
 
-			if (location) {
-				offering.location = location
-			}
+		if (location) {
+			offering.location = location
+		}
 
-			mergeWith(offerings[day], offering,
-				(a, b) => Array.isArray(a) ? a.concat(b) : undefined)
-		})
+		mergeWith(offerings[key], offering,
+			(a, b) => Array.isArray(a) ? a.concat(b) : undefined)
 	})
 
 	return values(offerings)

--- a/src/convert-time-strings-to-offerings.js
+++ b/src/convert-time-strings-to-offerings.js
@@ -5,7 +5,50 @@ import zip from 'lodash/zip'
 import findDays from './find-days'
 import findTime from './find-time'
 
-export default function convertTimeStringsToOfferings(course) {
+export default function convertTimeStringsToOfferings(course, {groupBy='day'}={}) {
+	// you may group by "day" or by "sis", where "sis" retains the groupings given by SIS
+
+	if (groupBy === 'day') {
+		return convertAndGroupByDay(course)
+	} else if (groupBy === 'sis') {
+		return convertAndGroupLikeSis(course)
+	} else {
+		throw new Error(`"${groupBy}" is not a valid groupBy mode`)
+	}
+}
+
+function convertAndGroupByDay(course) {
+	let offerings = {}
+
+	zip(course.times, course.locations).forEach(([sisTimestring, location]) => {
+		const [daystring, timestring] = sisTimestring.split(' ')
+
+		const days = findDays(daystring)
+		const time = findTime(timestring)
+
+		days.forEach(day => {
+			if (!offerings[day]) {
+				offerings[day] = {}
+			}
+
+			let offering = {
+				day: day,
+				times: [assign({}, time)],
+			}
+
+			if (location) {
+				offering.location = location
+			}
+
+			mergeWith(offerings[day], offering,
+				(a, b) => Array.isArray(a) ? a.concat(b) : undefined)
+		})
+	})
+
+	return values(offerings)
+}
+
+function convertAndGroupLikeSis(course) {
 	let offerings = {}
 
 	zip(course.times, course.locations).forEach(([sisTimestring, location]) => {

--- a/src/convert-time-strings-to-offerings.js
+++ b/src/convert-time-strings-to-offerings.js
@@ -58,18 +58,13 @@ function convertAndGroupLikeSis(course) {
 		const time = findTime(timestring)
 		const key = days.join(',')
 
-		if (!offerings[key]) {
-			offerings[key] = {}
-		}
-
 		let offering = {days, ...time}
 
 		if (location) {
 			offering.location = location
 		}
 
-		mergeWith(offerings[key], offering,
-			(a, b) => Array.isArray(a) ? a.concat(b) : undefined)
+		offerings[key] = offering
 	})
 
 	return values(offerings)


### PR DESCRIPTION
This PR adds an optional argument to `convertTimeStringsToOfferings` – it now supports `{groupBy: 'day' | 'sis'}` as the second argument.

```js
convertTimeStringsToOfferings(course, {groupBy: 'sis'})
```

If the argument is not given, it defaults to `'day'`.

```js
// Given this input…
let input = {times: ['MT 0100-0400PM', 'MF 0905-1000']}

// in "day" mode, we get this
let byDay = convertTimeStringsToOfferings(course, {groupBy: 'day'})
expect(byDay).toEqual([
	{day: 'Mo', times: [{start:1300, end:1600}, {start:905, end:1000}]},
	{day: 'Tu', times: [{start:1300, end:1600}]},
	{day: 'Fr', times: [{start:905,  end:1000}]},
])

// but in "sis" mode, we get this
let likeSis = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
expect(actual).toEqual([
	{days: ['Mo', 'Tu'], start:1300, end:1600},
	{days: ['Mo', 'Fr'], start:905,  end:1000},
])
```

This makes it easier to generate timestrings that look like what SIS would output.