### PR TITLE
Fix groupby sis overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 2.3.1
+- Fixed `{groupBy: sis}` to not overwrite the offerings if the same key is given twice
+
 ## 2.3.0
 - Added new `{groupBy: sis}` optional second parameter to `convertTimeStringsToOfferings`
     - It maintains the groupings that SIS gives us, instead of re-grouping multiple times into a single day

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ convertTimeStringsToOfferings(course, {groupBy: 'sis'})
 
 // output
 [
-    { days: ['Mo', 'Tu'], start: 1300, end: 1600 },
-    { days: ['Mo', 'Fr'], start: 905,  end: 1000 },
+    { days: ['Mo', 'Tu'], times: [{start: 1300, end: 1600}] },
+    { days: ['Mo', 'Fr'], times: [{start: 905,  end: 1000}] },
 ]
 ```

--- a/src/__tests__/convert-time-strings-to-offerings.test.js
+++ b/src/__tests__/convert-time-strings-to-offerings.test.js
@@ -98,8 +98,8 @@ describe('in groupBy=sis mode', () => {
 		let course = {times: ['MT 0100-0400PM', 'MF 0905-1000']}
 
 		let expected = [
-			{days: ['Mo', 'Tu'], start:1300, end:1600},
-			{days: ['Mo', 'Fr'], start:905,  end:1000},
+			{days: ['Mo', 'Tu'], times: [{start:1300, end:1600}]},
+			{days: ['Mo', 'Fr'], times: [{start:905,  end:1000}]},
 		]
 
 		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
@@ -114,8 +114,8 @@ describe('in groupBy=sis mode', () => {
 		}
 
 		let expected = [
-			{days: ['Mo', 'Tu'], start:1300, end:1600, location: 'TOH 103'},
-			{days: ['Mo', 'Fr'], start:905,  end:1000, location: 'RNS 203'},
+			{days: ['Mo', 'Tu'], times: [{start:1300, end:1600}], location: 'TOH 103'},
+			{days: ['Mo', 'Fr'], times: [{start:905,  end:1000}], location: 'RNS 203'},
 		]
 
 		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
@@ -123,11 +123,14 @@ describe('in groupBy=sis mode', () => {
 		expect(actual).toEqual(expected)
 	})
 
-	test('overwrites the offering if the same days are given again', () => {
+	test('does not overwrite the offering if the same days are given again', () => {
 		let course = {times: ['MT 0100-0400PM', 'MT 0905-1000']}
 
 		let expected = [
-			{days: ['Mo', 'Tu'], start:905, end:1000},
+			{days: ['Mo', 'Tu'], times: [
+				{start:1300, end:1600},
+				{start:905,  end:1000},
+			]},
 		]
 
 		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})
@@ -142,8 +145,8 @@ describe('in groupBy=sis mode', () => {
 		}
 
 		let expected = [
-			{days: ['Mo', 'Tu'], start:1300, end:1600, location: 'Place 1'},
-			{days: ['Tu', 'Mo'], start:905,  end:1000, location: 'Place 2'},
+			{days: ['Mo', 'Tu'], times: [{start:1300, end:1600}], location: 'Place 1'},
+			{days: ['Tu', 'Mo'], times: [{start:905,  end:1000}], location: 'Place 2'},
 		]
 
 		let actual = convertTimeStringsToOfferings(course, {groupBy: 'sis'})

--- a/src/convert-time-strings-to-offerings.js
+++ b/src/convert-time-strings-to-offerings.js
@@ -58,13 +58,20 @@ function convertAndGroupLikeSis(course) {
 		const time = findTime(timestring)
 		const key = days.join(',')
 
-		let offering = assign({}, {days}, time)
+		if (!offerings[key]) {
+			offerings[key] = {days: days}
+		}
+
+		let offering = {
+			times: [time],
+		}
 
 		if (location) {
 			offering.location = location
 		}
 
-		offerings[key] = offering
+		mergeWith(offerings[key], offering,
+			(a, b) => Array.isArray(a) ? a.concat(b) : undefined)
 	})
 
 	return values(offerings)


### PR DESCRIPTION
Followup to #31 

`groupBy: sis` now returns `{days: Array<DayOfWeek>, times: Array<{start, end}>, location: string}`, instead of only allowing one meeting time per set of days.

That is,

```js
// input
{times: ['MT 0100-0400PM', 'MT 0905-1000']}

// should return
[
	{days: ['Mo', 'Tu'], times: [
		{start:1300, end:1600},
		{start:905,  end:1000},
	]},
]
```

and 

```js
// input
{times: ['MT 0100-0400PM', 'MT 0905-1000', 'MTF 1045-1140']}

// should return
[
	{days: ['Mo', 'Tu'], times: [
		{start:1300, end:1600},
		{start:905,  end:1000},
	]},
	{days: ['Mo', 'Tu', 'Fr'], times: [
		{start:1045, end:1140},
	]},
]
```